### PR TITLE
Benchmark for index database

### DIFF
--- a/Benchmark/Benchmark.csproj
+++ b/Benchmark/Benchmark.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DataAccess\DataAccess.csproj" />
+    <ProjectReference Include="..\Domain\Domain.csproj" />
+    <ProjectReference Include="..\Services\Services.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Benchmark/DbPerformance.cs
+++ b/Benchmark/DbPerformance.cs
@@ -1,0 +1,119 @@
+﻿using AutoMapper;
+using BenchmarkDotNet.Attributes;
+using DataAccess;
+using Domain;
+using Domain.Dto.BetableEntity;
+using Domain.Dto.BetQuote;
+using Domain.Dto.Bets;
+using Services;
+using Services.Interfaces;
+using System.Diagnostics;
+
+namespace Benchmark
+{
+    public class DbPerformance
+    {
+        private readonly string benchmarkConnectionString = "Server=localhost;Database=BenchmarkBetsDatabase;TrustServerCertificate=true;Trusted_Connection=true;";
+        private readonly int noEntities = 2;
+        private readonly int noBets = 10;
+        private List<Guid> entitiesId, betsId;
+        public DBContext _dBContext;
+        public IBetableEntityService _entityService;
+        public IBetsService _betsService;
+        public IBetQuoteService _betQuoteService;
+
+        private void PrepareDb()
+        {
+            _dBContext = new DBContext(benchmarkConnectionString);
+            DbDatabaseCreation contextCreation = new DbDatabaseCreation(benchmarkConnectionString);
+            contextCreation.Database.EnsureCreated();
+            DatabaseMigrator.MigrateDb(benchmarkConnectionString);
+        }
+
+        private async Task SeedDB()
+        {
+            entitiesId = new List<Guid>();
+            for (int i = 0; i < noEntities; i++)
+            {
+                CreateBetableEntityDto createBetableEntityDto = new CreateBetableEntityDto { Name = $"BetableEntity {Guid.NewGuid()}" };
+                BetableEntityDto betableEntityDto = await _entityService.CreateAsync(createBetableEntityDto);
+                entitiesId.Add(betableEntityDto.Id);
+            }
+        }
+        private decimal GetRandomDecimal(decimal minValue, decimal maxValue, Random random)
+        {
+            double randomDouble = random.NextDouble();
+            decimal scaledValue = (decimal)randomDouble * (maxValue - minValue) + minValue;
+
+            return scaledValue;
+        }
+
+        [IterationSetup]
+        public async Task Setup()
+        {
+            PrepareDb();
+            var config = new MapperConfiguration(cfg => cfg.AddProfile<MapperConfig>());
+            IMapper mapper = config.CreateMapper();
+            _entityService = new BetableEntityService(_dBContext, mapper);
+            _betsService = new BetsService(_dBContext, TimeProvider.System, _entityService, mapper);
+            _betQuoteService = new BetQuoteService(_dBContext, mapper);
+            await SeedDB();
+        }
+
+        [IterationCleanup]
+        public async Task CleanUp()
+        {
+            await _dBContext.Database.EnsureDeletedAsync();
+        }
+        
+        public async Task CreateBets()
+        {
+            Random random = new Random();
+            betsId = new List<Guid>();
+            Guid betableEntityA = entitiesId.First();
+            Guid betableEntityB = entitiesId.Last();
+
+            Stopwatch stopwatch = new Stopwatch();
+            stopwatch.Start();
+
+            for (int i = 0; i < noBets; i++)
+            {
+                CreateBetsDto newBet = new CreateBetsDto
+                {
+                    Name = $"Bet {Guid.NewGuid()}",
+                    BetableEntityA = betableEntityA,
+                    BetableEntityB = betableEntityB,
+                };
+                CreateBetQuotesDto newBetQuote = new CreateBetQuotesDto
+                {
+                    QuoteA = 2.34m,
+                    QuoteB = 82.2m,
+                    QuoteX = 34.79m
+                };
+                BetsDto betsDto = await _betsService.CreateAsync(newBet);
+                BetQuoteDto betQuoteDto = await _betQuoteService.CreateAsync(newBetQuote, betsDto.Id);
+                betsId.Add(betsDto.Id);
+            }
+
+            stopwatch.Stop();
+            TimeSpan elapsedTime = stopwatch.Elapsed;
+            Console.WriteLine($"Took {elapsedTime.TotalSeconds} s to CREATE {noBets} bets");
+
+        }
+
+        public async Task GetQuoteByBetsId()
+        {
+            Stopwatch stopwatch = new Stopwatch();
+            stopwatch.Start();
+
+            foreach (Guid id in betsId.AsEnumerable())
+            {
+                await _betQuoteService.GetByBetIdAsync(id);
+            }
+
+            stopwatch.Stop();
+            TimeSpan elapsedTime = stopwatch.Elapsed;
+            Console.WriteLine($"Took {elapsedTime.TotalSeconds} s to GET {noBets} bets");
+        }
+    }
+}

--- a/Benchmark/Program.cs
+++ b/Benchmark/Program.cs
@@ -1,0 +1,18 @@
+﻿using BenchmarkDotNet.Running;
+
+namespace Benchmark
+{
+    class Program
+    {
+        static async Task Main(string[] args)
+        {
+            DbPerformance dbPerformance = new DbPerformance();
+            await dbPerformance.Setup();
+
+            await dbPerformance.CreateBets();
+            await dbPerformance.GetQuoteByBetsId();
+
+            await dbPerformance.CleanUp();
+        }
+    }
+}

--- a/BetsApi.sln
+++ b/BetsApi.sln
@@ -31,6 +31,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Seeder", "Seeder\Seeder.csp
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UnitTesting", "UnitTesting\UnitTesting.csproj", "{F628468D-C3BB-4357-94C3-5790F50D3E96}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Benchmark", "Benchmark\Benchmark.csproj", "{BDCA926C-E762-4814-9C51-8ECC623A275E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -61,6 +63,10 @@ Global
 		{F628468D-C3BB-4357-94C3-5790F50D3E96}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F628468D-C3BB-4357-94C3-5790F50D3E96}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F628468D-C3BB-4357-94C3-5790F50D3E96}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BDCA926C-E762-4814-9C51-8ECC623A275E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BDCA926C-E762-4814-9C51-8ECC623A275E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BDCA926C-E762-4814-9C51-8ECC623A275E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BDCA926C-E762-4814-9C51-8ECC623A275E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/BetsApi/BetsApi.csproj
+++ b/BetsApi/BetsApi.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="AutoMapper" Version="13.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
   </ItemGroup>

--- a/DataAccess/DBContext.cs
+++ b/DataAccess/DBContext.cs
@@ -39,6 +39,5 @@ namespace DataAccess
                 .Property(quote => quote.QuoteX)
                 .HasPrecision(5, 2);
         }
-
     }
 }

--- a/DataAccess/DbDatabaseCreation.cs
+++ b/DataAccess/DbDatabaseCreation.cs
@@ -15,9 +15,9 @@ namespace DataAccess
 
         }
 
-        private static DbContextOptions<DBContext> GetOptions(string connectionString)
+        private static DbContextOptions<DbDatabaseCreation> GetOptions(string connectionString)
         {
-            var optionsBuilder = new DbContextOptionsBuilder<DBContext>();
+            var optionsBuilder = new DbContextOptionsBuilder<DbDatabaseCreation>();
             optionsBuilder.UseSqlServer(connectionString);
             return optionsBuilder.Options;
         }

--- a/DataAccess/Migrations/Migration_202407154_Add_Entities.cs
+++ b/DataAccess/Migrations/Migration_202407154_Add_Entities.cs
@@ -7,6 +7,7 @@ namespace DataAccess.Migrations
     {
         public override void Up()
         {
+            Console.WriteLine("O face vere");
             Create.Table("BetableEntity")
                 .WithColumn("Id").AsGuid().PrimaryKey().WithDefault(SystemMethods.NewGuid)
                 .WithColumn("Name").AsString(255);

--- a/DataAccess/Migrations/Migration_202408061_Bets_AddIndex.cs
+++ b/DataAccess/Migrations/Migration_202408061_Bets_AddIndex.cs
@@ -1,0 +1,28 @@
+﻿using FluentMigrator;
+
+namespace DataAccess.Migrations
+{
+    [Migration(202408061)]
+    public class Migration_202408061_Bets_AddIndex : Migration
+    {
+        public override void Up()
+        {
+            Create.Index("IX_Bets_BetableEntityA")
+                  .OnTable("Bets")
+                  .OnColumn("BetableEntityA")
+                  .Ascending();
+
+
+            Create.Index("IX_Bets_BetableEntityB")
+                  .OnTable("Bets")
+                  .OnColumn("BetableEntityB")
+                  .Ascending();
+
+        }
+
+        public override void Down()
+        {
+            Delete.Index("IX_Bets_BetableEntityA").OnTable("Bets");
+        }
+    }
+}

--- a/DataAccess/Migrations/Migration_202408062_BetQuote_AddIndex.cs
+++ b/DataAccess/Migrations/Migration_202408062_BetQuote_AddIndex.cs
@@ -1,0 +1,22 @@
+﻿using FluentMigrator;
+
+namespace DataAccess.Migrations
+{
+    [Migration(202408062)]
+    public class Migration_202408062_BetQuote_AddIndex : Migration
+    {
+        public override void Up()
+        {
+            Create.Index("IX_BetQuotes_BetId")
+                  .OnTable("BetQuotes")
+                  .OnColumn("BetId")
+                  .Ascending()
+                  .WithOptions().Unique();
+        }
+
+        public override void Down()
+        {
+            Delete.Index("IX_BetQuotes_BetId").OnTable("BetId");
+        }
+    }
+}


### PR DESCRIPTION
I intended to determine the significance of an index in the table with these tests. The "BetQuotes" table is the primary table I was interested in seeing this in. I looked into the betId field and how I could increase its value by building an index around it. To illustrate this distinction, I utilized the betQuoteService. GetByBetIdAsync(betId) method.

The first benchmark represents the results for the initial databases without any index in the tables:
![image](https://github.com/user-attachments/assets/25b9fbc9-a3f0-4384-9aa3-b58e3d35ea78)
2252 seconds for creating => 2252/60=37.5 min
238 seconds for get operation => 238/60 = 4 min

Second benchmark represent the results for the database where I added only the index, without any other additional option:
![image (1)](https://github.com/user-attachments/assets/750b3799-7d4e-4325-8fd6-0c06e9b0245e)
2887 seconds for creating => 2887/60= 48 min
36.9 seconds for get operation

And the latest benchmark represents the result for the database with a unique index on the field betId from the betQuotes tables.
![image (2)](https://github.com/user-attachments/assets/eb0635a7-9141-493a-b563-97b2f5f23dbf)
2369 seconds for creating =>  2369/60 = 39.5 min
36.7 seconds for get operation
